### PR TITLE
Update bson package path

### DIFF
--- a/bson/bson_codec.go
+++ b/bson/bson_codec.go
@@ -2,7 +2,7 @@ package bson
 
 import (
 	"github.com/stretchr/codecs/constants"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // BsonCodec converts objects to and from BSON.


### PR DESCRIPTION
I cannot install bson package from `labix.org/v2/mgo/bson`(Bazaar repository). https://labix.org/gobson page says bson package is available from `gopkg.in/mgo.v2/bson`(Git repository) now. I confirmed tests in bson directory are passed with `gopkg.in/mgo.v2/bson` as below.

```
% go test -v
=== RUN   TestInterface
--- PASS: TestInterface (0.00s)
=== RUN   TestMarshal
--- PASS: TestMarshal (0.00s)
=== RUN   TestUnmarshal
--- PASS: TestUnmarshal (0.00s)
=== RUN   TestResponseContentType
--- PASS: TestResponseContentType (0.00s)
=== RUN   TestFileExtension
--- PASS: TestFileExtension (0.00s)
=== RUN   TestCanMarshalWithCallback
--- PASS: TestCanMarshalWithCallback (0.00s)
PASS
ok      github.com/stretchr/codecs/bson 0.003s
```

See
- https://labix.org/gobson
